### PR TITLE
Symbolize from proc maps

### DIFF
--- a/cmd/utrace/run/cmd.go
+++ b/cmd/utrace/run/cmd.go
@@ -41,15 +41,15 @@ func init() {
 		false,
 		`when set, utrace will generate a .dot graph with the collected statistics`)
 	Utrace.Flags().VarP(
-		NewUTraceOptionsSanitizer(&options.UTraceOptions, "binary"),
-		"binary",
-		"b",
-		`list of paths to the binaries you want to trace`)
+		NewUTraceOptionsSanitizer(&options.UTraceOptions, "executable"),
+		"executable",
+		"e",
+		`list of paths to the executables you want to trace`)
 	Utrace.Flags().VarP(
 		NewUTraceOptionsSanitizer(&options.UTraceOptions, "pattern"),
 		"pattern",
 		"p",
-		`user space function(s) pattern to trace`)
+		`user space function(s) pattern to trace, optionally prefixed with a path to binary containing these functions (eg. '/lib/x86_64-linux-gnu/libc.so.6:malloc')`)
 	Utrace.Flags().VarP(
 		NewUTraceOptionsSanitizer(&options.UTraceOptions, "kernel-pattern"),
 		"kernel-pattern",

--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,13 @@ go 1.15
 
 require (
 	github.com/DataDog/ebpf-manager v0.0.0-20220113113843-c3e09dfcb60c
+	github.com/DataDog/gopsutil v0.0.0-20211117161807-6301733ae21b
 	github.com/cilium/ebpf v0.7.1-0.20211227144435-70d770f1e5f9
 	github.com/pkg/errors v0.9.1
 	github.com/shuLhan/go-bindata v4.0.0+incompatible
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.1.1
+	github.com/stretchr/testify v1.3.0
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/sys v0.0.0-20210921065528-437939a70204
 )

--- a/go.sum
+++ b/go.sum
@@ -13,14 +13,11 @@ cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiy
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/DataDog/ebpf-manager v0.0.0-20220111092842-0c445a76d299 h1:KIbjlZP//7FgPR1x/mmUnJpwVXaHkOSPXXC3ws21Rd8=
-github.com/DataDog/ebpf-manager v0.0.0-20220111092842-0c445a76d299/go.mod h1:q6FEcnn+mlqeRyd+nNN/xuoHfVKVsZav5k3xEIQxkpI=
-github.com/DataDog/ebpf-manager v0.0.0-20220112215545-53ccf6db5fc5 h1:TcMuL1efB6EYeDB5UCOaTe1ixLXrH1VdNpWqrh16b+c=
-github.com/DataDog/ebpf-manager v0.0.0-20220112215545-53ccf6db5fc5/go.mod h1:q6FEcnn+mlqeRyd+nNN/xuoHfVKVsZav5k3xEIQxkpI=
 github.com/DataDog/ebpf-manager v0.0.0-20220113113843-c3e09dfcb60c h1:CCmCq3xAb0nrkDsJcmRSswY1ISwlsRhs3aq8cTcrHsY=
 github.com/DataDog/ebpf-manager v0.0.0-20220113113843-c3e09dfcb60c/go.mod h1:q6FEcnn+mlqeRyd+nNN/xuoHfVKVsZav5k3xEIQxkpI=
-github.com/DataDog/gopsutil v0.0.0-20200624212600-1b53412ef321 h1:OPAXA+r6yznoxWR5jQ2iTh5CvzIMrdw8AU0uFN2RwEw=
 github.com/DataDog/gopsutil v0.0.0-20200624212600-1b53412ef321/go.mod h1:tGQp6XG4XpOyy67WG/YWXVxzOY6LejK35e8KcQhtRIQ=
+github.com/DataDog/gopsutil v0.0.0-20211117161807-6301733ae21b h1:s3YBoPJLDVmaHdrTyFh5IvCGPT/9Axk+IAP7EEJwwKA=
+github.com/DataDog/gopsutil v0.0.0-20211117161807-6301733ae21b/go.mod h1:glkxNt/qRu9lnpmUEQwOIAXW+COWDTBOTEAHqbgBPts=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/StackExchange/wmi v0.0.0-20181212234831-e0a55b97c705 h1:UUppSQnhf4Yc6xGxSkoQpPhb7RVzuv5Nb1mwJ5VId9s=
 github.com/StackExchange/wmi v0.0.0-20181212234831-e0a55b97c705/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
@@ -328,6 +325,7 @@ golang.org/x/sys v0.0.0-20210110051926-789bb1bd4061/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210123111255-9b0068b26619/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210216163648-f7da38b97c65/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210906170528-6f6e22806c34/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210921065528-437939a70204 h1:JJhkWtBuTQKyz2bd5WG9H8iUsJRU3En/KRfN8B2RnDs=
 golang.org/x/sys v0.0.0-20210921065528-437939a70204/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/pkg/utrace/model.go
+++ b/pkg/utrace/model.go
@@ -61,15 +61,20 @@ type BinaryCookie uint32
 // PathMax - Maximum path length of the binary path handled by utrace
 const PathMax = 350
 
+type FuncPattern struct {
+	Pattern     *regexp.Regexp
+	Binary 		string
+}
+
 // Options contains the parameters of UTrace
 type Options struct {
-	FuncPattern       *regexp.Regexp
+	FuncPattern       *FuncPattern
 	KernelFuncPattern *regexp.Regexp
 	Tracepoints       []string
 	PerfEvents        []string
 	Latency           bool
 	StackTraces       bool
-	Binary            []string
+	Executables       []string
 	PIDFilter         []int
 }
 
@@ -77,7 +82,7 @@ func (o Options) check() error {
 	if o.FuncPattern == nil && o.KernelFuncPattern == nil {
 		return EmptyPatternsErr
 	}
-	if o.FuncPattern != nil && len(o.Binary) == 0 {
+	if o.FuncPattern != nil && len(o.Executables) == 0 {
 		return EmptyBinaryPathErr
 	}
 	return nil

--- a/pkg/utrace/model.go
+++ b/pkg/utrace/model.go
@@ -353,6 +353,13 @@ func (te *TraceEvent) UnmarshalBinary(data []byte) (int, error) {
 	return 24, nil
 }
 
+// represents a traced function inside of a binary
+type TracedFunc struct {
+	FuncID       FuncID
+	Pids         []int
+	TracedBinary *TracedBinary
+}
+
 type TracedBinary struct {
 	Path         string
 	ResolvedPath string

--- a/pkg/utrace/object_model_proposal.txt
+++ b/pkg/utrace/object_model_proposal.txt
@@ -1,0 +1,45 @@
+
+Options
+---
+PIDs: Find all binaries associated to these PIDs. uprobe is placed on a binary associated to these PIDs (loaded from proc maps)
+
+BINARY: Associate uprobe to binary (no filter on PID unless explicitely given in other option).
+
+EXECUTABLE: Find all PIDs that run these executable, load all binaries associated. Allow to probe on all these binaries.
+
+Note:
+- PIDs and EXECUTABLE are mutually exclusive (for now at least)
+- BINARY if specified takes precedence on where we want to place the uprobe
+
+Function pattern is associated to one of the options above.
+example : --binary "libc malloc" --executable "exec1 fopen"
+TODO : find a separator
+
+
+FuncID 
+--- 
+Represents the function being probed (uprobe and retprobe have the same ID)
+Proposal: change to TracedFuncID ?
+
+
+TracedBinary
+---
+contains a file 
+pid list: this is not stored at the right place. Proposal : create a trace context structure.
+contains a symbol cache tied this file. Warning: addresses need to be independant from PID
+symbolNameToFuncID : issue. Malloc is available in several libraries. 
+Malloc has several IDs, a symbol name can match several IDs
+TBD : what do we do of this ?
+
+
+New object proposal 
+----------
+
+TracedFunc 
+----
+TracedFuncID
+Pids 
+pointer to Binary 
+
+
+

--- a/pkg/utrace/symbols.go
+++ b/pkg/utrace/symbols.go
@@ -9,12 +9,6 @@ import (
 	"github.com/DataDog/gopsutil/process"
 )
 
-type SymbolInfo struct {
-	elf.Symbol
-	Path        string
-	ProcessAddr SymbolAddr
-	FileOffset  SymbolAddr
-}
 
 func ListProcMaps(pid int) (*[]process.MemoryMapsStat, error) {
 	p, err := process.NewProcess(int32(pid))

--- a/pkg/utrace/symbols.go
+++ b/pkg/utrace/symbols.go
@@ -1,0 +1,94 @@
+package utrace
+
+import (
+	"debug/elf"
+	"fmt"
+	"strings"
+
+	manager "github.com/DataDog/ebpf-manager"
+	"github.com/DataDog/gopsutil/process"
+)
+
+type SymbolInfo struct {
+	elf.Symbol
+	Path        string
+	ProcessAddr SymbolAddr
+	FileOffset  SymbolAddr
+}
+
+func ListProcMaps(pid int) (*[]process.MemoryMapsStat, error) {
+	p, err := process.NewProcess(int32(pid))
+	if err != nil {
+		return nil, err
+	}
+	procMaps, err := p.MemoryMaps(true)
+	if err != nil {
+		return nil, err
+	}
+	filteredProcMaps := []process.MemoryMapsStat{}
+	for _, m := range *procMaps {
+		if m.Permission.Execute && !strings.HasPrefix(m.Path, "[") {
+			filteredProcMaps = append(filteredProcMaps, m)
+		}
+	}
+
+	return &filteredProcMaps, nil
+}
+
+func ListSymbolsFromProcMaps(procMaps *[]process.MemoryMapsStat, symbols *[]SymbolInfo) error {
+	for _, m := range *procMaps {
+		f, syms, err := manager.OpenAndListSymbols(m.Path)
+		if err != nil {
+			fmt.Println("[error] ListSymbols: Skipping", m.Path)
+			continue
+		}
+		//fmt.Printf("Processing %50s, Start: %x, End: 0x%x, Offset: 0x%x\n", m.Path, m.StartAddr, m.EndAddr, m.Offset)
+
+		seenSymbols := make(map[string]bool)
+
+		// from the entire list of symbols, only keep the functions that match the provided pattern
+		for _, sym := range syms {
+			if len(sym.Version) > 0 {
+				// skip dynamic symbols
+				continue
+			}
+
+			value := sym.Value
+			for _, prog := range f.Progs {
+				if prog.Type == elf.PT_LOAD {
+					if value >= prog.Vaddr && value < (prog.Vaddr+prog.Memsz) {
+						value = sym.Value - prog.Vaddr + prog.Off
+					}
+				}
+			}
+
+			if value < m.Offset {
+				// errors we still need to understand
+				//fmt.Println("[error] ListSymbols:  Skipping symbol", sym)
+				continue
+			}
+
+			if !seenSymbols[sym.Name] {
+				// a symbol might be present in both standard and dynamic symbols
+				processAddr := SymbolAddr(value) - SymbolAddr(m.Offset) + SymbolAddr(m.StartAddr)
+				*symbols = append(*symbols, SymbolInfo{sym, m.Path, processAddr, SymbolAddr(value)})
+				seenSymbols[sym.Name] = true
+			}
+		}
+	}
+
+	return nil
+}
+
+func ListSymbolsFromPID(pid int) ([]SymbolInfo, error) {
+	procMaps, err := ListProcMaps(pid)
+	if err != nil {
+		return nil, err
+	}
+	var symbols []SymbolInfo
+	err = ListSymbolsFromProcMaps(procMaps, &symbols)
+	if err != nil {
+		return nil, err
+	}
+	return symbols, nil
+}

--- a/pkg/utrace/symbols_test.go
+++ b/pkg/utrace/symbols_test.go
@@ -1,0 +1,16 @@
+package utrace
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestListSymbols(t *testing.T) {
+	pid := os.Getpid()
+	symbols, err := ListSymbolsFromPID(pid)
+	require.NoError(t, err)
+	fmt.Println("map:", symbols)
+}

--- a/pkg/utrace/utrace.go
+++ b/pkg/utrace/utrace.go
@@ -58,6 +58,9 @@ type UTrace struct {
 	// kernelSymbolNameToFuncID contains the FuncID attributed to each kernel symbol
 	kernelSymbolNameToFuncID map[string]FuncID
 
+	procMapsCache map[int]*ProcMapRanges
+	symbolCache   map[string]*BinarySymbols
+
 	// funcCache holds the traced symbol associated to each FuncID (kernel and userspace)
 	funcCache map[FuncID]TracedSymbol
 	// stackTraces holds the list of collected stack traces for all FuncID (kernel and unserspace)
@@ -78,6 +81,8 @@ func NewUTrace(options Options) *UTrace {
 		options:                  options,
 		funcCache:                make(map[FuncID]TracedSymbol),
 		kernelSymbolNameToFuncID: make(map[string]FuncID),
+		procMapsCache:            make(map[int]*ProcMapRanges),
+		symbolCache:              make(map[string]*BinarySymbols),
 		kallsymsCache:            make(map[SymbolAddr]elf.Symbol),
 		stackTraces:              make(map[FuncID]map[CombinedID]*StackTrace),
 		TracedBinaries:           make(map[BinaryCookie]*TracedBinary),
@@ -351,12 +356,10 @@ func (u *UTrace) start() error {
 	}
 
 	// generate uprobes if a binary file is provided
-	if u.options.FuncPattern != nil {
-		for _, binary := range u.TracedBinaries {
-			if err = u.generateUProbes(binary); err != nil {
-				return fmt.Errorf("couldn't generate uprobes: %w", err)
-			}
-		}
+	if u.options.FuncPattern != nil {		
+		if err = u.generateUProbes(); err != nil {
+			return fmt.Errorf("couldn't generate uprobes: %w", err)
+		}		
 	}
 
 	// setup kprobes if a kernel function pattern was provided
@@ -375,16 +378,8 @@ func (u *UTrace) start() error {
 
 	// setup perf events
 	if len(u.options.PerfEvents) > 0 {
-		if len(u.TracedBinaries) == 0 {
-			if err = u.generatePerfEvents(nil); err != nil {
-				return fmt.Errorf("couldn't generate perf events: %w", err)
-			}
-		} else {
-			for _, binary := range u.TracedBinaries {
-				if err = u.generatePerfEvents(binary); err != nil {
-					return fmt.Errorf("couldn't generate perf events: %w", err)
-				}
-			}
+		if err = u.generatePerfEvents(u.options.PIDFilter); err != nil {
+			return fmt.Errorf("couldn't generate perf events: %w", err)
 		}
 	}
 
@@ -446,33 +441,84 @@ func (u *UTrace) pushKernelFilters() error {
 	return nil
 }
 
-func (u *UTrace) generateUProbes(binary *TracedBinary) error {
-	if u.options.FuncPattern == nil || binary == nil {
-		return nil
+func ComputeFileOffset(f *elf.File, sym elf.Symbol) uint64 {
+	// If the binary is a non-PIE executable, addr must be a virtual address, otherwise it must be an offset relative to
+	// the file load address. For executable (ET_EXEC) binaries and shared objects (ET_DYN), translate the virtual
+	// address to physical address in the binary file.
+	if f.Type == elf.ET_EXEC || f.Type == elf.ET_DYN {
+		for _, prog := range f.Progs {
+			if prog.Type == elf.PT_LOAD {
+				if sym.Value >= prog.Vaddr && sym.Value < (prog.Vaddr+prog.Memsz) {
+					return sym.Value - prog.Vaddr + prog.Off
+				}
+			}
+		}
 	}
+	return sym.Value
+}
 
-	// from the entire list of symbols, only keep the functions that match the provided pattern
-	var matches []elf.Symbol
-	for _, sym := range binary.symbolsCache {
-		if elf.ST_TYPE(sym.Info) == elf.STT_FUNC && u.options.FuncPattern.Pattern.MatchString(sym.Name) {
-			matches = append(matches, sym)
+func (u *UTrace) generateUProbes() error {
+	if u.options.FuncPattern.Binary != "" {
+		binaryPath := u.options.FuncPattern.Binary
+		// from the entire list of symbols, only keep the functions that match the provided pattern
+		var matches []SymbolInfo
+		f, syms, err := manager.OpenAndListSymbols(binaryPath)
+		if err != nil {
+			return err
+		}
+
+		for _, sym := range syms {
+			if elf.ST_TYPE(sym.Info) == elf.STT_FUNC && u.options.FuncPattern.Pattern.MatchString(sym.Name) {
+				matches = append(matches, SymbolInfo{sym, binaryPath, SymbolAddr(0), 
+					SymbolAddr(ComputeFileOffset(f, sym))})
+			}
+		}
+
+		if uint32(len(matches)) > MaxUserSymbolsCount {
+			logrus.Warnf("%d symbols matched the provided pattern, only the first %d symbols will be traced.", len(matches), MaxUserSymbolsCount)
+			matches = matches[0:MaxUserSymbolsCount]
+		}
+	
+		if len(matches) == 0 {
+			return fmt.Errorf("no symbol in '%s' match the provided pattern '%s'", binaryPath, u.options.FuncPattern.Pattern.String())
+		}
+
+		for _, sym := range matches {
+			if err:=u.generateUProbe(sym, u.options.PIDFilter); err!=nil {
+				return err
+			}
+		}
+	} else {
+		if len(u.options.PIDFilter) == 0 {
+			return errors.New("A PID or binary is required for uprobe")
+		}
+
+		var matches []SymbolInfo
+		for _, pid := range u.options.PIDFilter {
+			syms, err := ListSymbolsFromPID(pid)
+			if err != nil {
+				return err
+			}
+			
+			for _, symInfo := range syms {
+				if elf.ST_TYPE(symInfo.Info) == elf.STT_FUNC && u.options.FuncPattern.Pattern.MatchString(symInfo.Name) {
+					matches = append(matches, symInfo)
+				}
+			}
+			for _, sym := range matches {
+				if err := u.generateUProbe(sym, []int{pid}); err != nil {
+					return err
+				}
+			}
 		}
 	}
 
-	if uint32(len(matches)) > MaxUserSymbolsCount {
-		logrus.Warnf("%d symbols matched the provided pattern, only the first %d symbols will be traced.", len(matches), MaxUserSymbolsCount)
-		matches = matches[0:MaxUserSymbolsCount]
-	}
+	return nil
+}
 
-	if len(matches) == 0 {
-		return fmt.Errorf("no symbol in '%s' match the provided pattern '%s'", binary.Path, u.options.FuncPattern.Pattern.String())
-	}
-
-	// relocate the function address with the base address of the binary
-	manager.SanitizeUprobeAddresses(binary.file, matches)
-
+func (u *UTrace) generateUProbe(sym SymbolInfo, pids []int) error {
 	// generate a probe for each traced PID, or a generic one that will match all pids
-	tracedPIDs := binary.Pids[:]
+	tracedPIDs := pids
 	if len(tracedPIDs) == 0 {
 		tracedPIDs = []int{0}
 	}
@@ -480,70 +526,67 @@ func (u *UTrace) generateUProbes(binary *TracedBinary) error {
 	var oneOfSelector manager.OneOf
 	var constantEditors []manager.ConstantEditor
 
-	// configure a probe for each symbol we're going to hook onto
-	for _, sym := range matches {
-		escapedName := sanitizeFuncName(sym.Name)
-		funcID := u.nextFuncID()
+	escapedName := sanitizeFuncName(sym.Name)
+	funcID := u.nextFuncID()
 
-		for _, pid := range tracedPIDs {
-			probeUID := RandomStringWithLen(10)
-			probe := &manager.Probe{
+	for _, pid := range tracedPIDs {
+		probeUID := RandomStringWithLen(10)
+		probe := &manager.Probe{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          probeUID,
+				EBPFSection:  "uprobe/utrace",
+				EBPFFuncName: "uprobe_utrace",
+			},
+			CopyProgram:   true,
+			BinaryPath:    sym.BinaryPath,
+			UprobeOffset:  uint64(sym.FileOffset),
+			MatchFuncName: fmt.Sprintf(`^%s$`, escapedName),
+		}
+		u.manager.Probes = append(u.manager.Probes, probe)
+		oneOfSelector.Selectors = append(oneOfSelector.Selectors, &manager.ProbeSelector{
+			ProbeIdentificationPair: probe.ProbeIdentificationPair,
+		})
+		constantEditors = append(constantEditors, manager.ConstantEditor{
+			Name:  "func_id",
+			Value: uint64(funcID),
+			ProbeIdentificationPairs: []manager.ProbeIdentificationPair{
+				probe.ProbeIdentificationPair,
+			},
+		})
+		if pid > 0 {
+			probe.PerfEventPID = pid
+		}
+
+		if u.options.Latency {
+			retProbe := &manager.Probe{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
 					UID:          probeUID,
-					EBPFSection:  "uprobe/utrace",
-					EBPFFuncName: "uprobe_utrace",
+					EBPFSection:  "uretprobe/utrace",
+					EBPFFuncName: "uretprobe_utrace",
 				},
 				CopyProgram:   true,
-				BinaryPath:    binary.Path,
-				UprobeOffset:  sym.Value,
+				BinaryPath:    sym.BinaryPath,
+				UprobeOffset:  uint64(sym.FileOffset),
 				MatchFuncName: fmt.Sprintf(`^%s$`, escapedName),
 			}
-			u.manager.Probes = append(u.manager.Probes, probe)
+			u.manager.Probes = append(u.manager.Probes, retProbe)
 			oneOfSelector.Selectors = append(oneOfSelector.Selectors, &manager.ProbeSelector{
-				ProbeIdentificationPair: probe.ProbeIdentificationPair,
+				ProbeIdentificationPair: retProbe.ProbeIdentificationPair,
 			})
 			constantEditors = append(constantEditors, manager.ConstantEditor{
 				Name:  "func_id",
 				Value: uint64(funcID),
 				ProbeIdentificationPairs: []manager.ProbeIdentificationPair{
-					probe.ProbeIdentificationPair,
+					retProbe.ProbeIdentificationPair,
 				},
 			})
 			if pid > 0 {
-				probe.PerfEventPID = pid
+				retProbe.PerfEventPID = pid
 			}
-
-			if u.options.Latency {
-				retProbe := &manager.Probe{
-					ProbeIdentificationPair: manager.ProbeIdentificationPair{
-						UID:          probeUID,
-						EBPFSection:  "uretprobe/utrace",
-						EBPFFuncName: "uretprobe_utrace",
-					},
-					CopyProgram:   true,
-					BinaryPath:    binary.Path,
-					UprobeOffset:  sym.Value,
-					MatchFuncName: fmt.Sprintf(`^%s$`, escapedName),
-				}
-				u.manager.Probes = append(u.manager.Probes, retProbe)
-				oneOfSelector.Selectors = append(oneOfSelector.Selectors, &manager.ProbeSelector{
-					ProbeIdentificationPair: retProbe.ProbeIdentificationPair,
-				})
-				constantEditors = append(constantEditors, manager.ConstantEditor{
-					Name:  "func_id",
-					Value: uint64(funcID),
-					ProbeIdentificationPairs: []manager.ProbeIdentificationPair{
-						retProbe.ProbeIdentificationPair,
-					},
-				})
-				if pid > 0 {
-					retProbe.PerfEventPID = pid
-				}
-			}
-
-			u.funcCache[funcID] = TracedSymbol{symbol: sym, binary: binary}
-			binary.symbolNameToFuncID[sym.Name] = funcID
 		}
+
+		u.funcCache[funcID] = TracedSymbol{symbol: sym.Symbol, binary: nil}
+		// binary.symbolNameToFuncID[sym.Name] = funcID
 	}
 
 	u.managerOptions.ActivatedProbes = append(u.managerOptions.ActivatedProbes, &oneOfSelector)
@@ -760,7 +803,7 @@ func (u *UTrace) generateTracepoints() error {
 	return nil
 }
 
-func (u *UTrace) generatePerfEvents(binary *TracedBinary) error {
+func (u *UTrace) generatePerfEvents(pids []int) error {
 	if err := u.parseKallsyms(); err != nil {
 		return errors.Wrap(err, "couldn't parse /proc/kallsyms")
 	}
@@ -771,10 +814,7 @@ func (u *UTrace) generatePerfEvents(binary *TracedBinary) error {
 	}
 
 	// generate a probe for each traced PID, or a generic one that will match all pids
-	var tracedPIDs []int
-	if binary != nil {
-		tracedPIDs = binary.Pids[:]
-	}
+	tracedPIDs := pids
 	if len(tracedPIDs) == 0 {
 		tracedPIDs = []int{0}
 	}
@@ -851,31 +891,120 @@ func (u *UTrace) generatePerfEvents(binary *TracedBinary) error {
 	return nil
 }
 
-// ResolveUserSymbolAndOffset returns the symbol of the function in which a given address lives, as well as the offset
-// inside that function
-func (u *UTrace) ResolveUserSymbolAndOffset(address SymbolAddr, binary *TracedBinary) StackTraceNode {
-	if binary != nil {
-		for symbolAddr, symbol := range binary.symbolsCache {
-			if address >= symbolAddr && address < symbolAddr+SymbolAddr(symbol.Size) {
-				funcID, ok := binary.symbolNameToFuncID[symbol.Name]
-				if !ok {
-					funcID = -1
-				}
-				return StackTraceNode{
-					Type:   User,
-					Symbol: symbol,
-					FuncID: funcID,
-					Offset: address - symbolAddr,
+func BuildProcMapRanges(pid int) (*ProcMapRanges, error) {
+	procMaps, err := ListProcMaps(pid)
+	if err != nil {
+		return nil, err
+	}
+	var procMapRanges ProcMapRanges
+	for _, m := range *procMaps {
+		procMapRanges = append(procMapRanges, ProcMapRange{	Start: uint64(m.StartAddr), 
+															End: uint64(m.EndAddr),
+															Offset: uint64(m.Offset),
+															BinaryPath: m.Path})
+	}
+	procMapRanges.Sort()
+	return &procMapRanges, nil
+}
+
+func LoadSymbols(binaryPath string) (*BinarySymbols, error) {
+	f, syms, err := manager.OpenAndListSymbols(binaryPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var symbols BinarySymbols
+	seenSymbols := make(map[string]bool)
+	for _, sym := range syms {
+		value := sym.Value
+		if len(sym.Version) > 0 || sym.Value == 0 {
+			continue
+		}
+
+		for _, prog := range f.Progs {
+			if prog.Type == elf.PT_LOAD {
+				if value >= prog.Vaddr && value < (prog.Vaddr+prog.Memsz) {
+					sym.Value = sym.Value - prog.Vaddr + prog.Off
 				}
 			}
 		}
+
+		if !seenSymbols[sym.Name] {
+			// a symbol might be present in both standard and dynamic symbols
+			symbols = append(symbols, sym)
+			seenSymbols[sym.Name] = true
+		}
+	}
+	symbols.Sort()
+	return &symbols, nil
+}
+
+func (u *UTrace) GetProcMapRange(address SymbolAddr, pid int) *ProcMapRange {
+	procMapRanges, ok := u.procMapsCache[pid]
+	if !ok {
+		procMapRanges, _ = BuildProcMapRanges(pid)
+		u.procMapsCache[pid] = procMapRanges
+	}
+	if procMapRanges == nil {
+		return nil
+	}	
+	return procMapRanges.Search(uint64(address))
+}
+
+func (u *UTrace) GetSymbols(procMapRange *ProcMapRange) *BinarySymbols {
+	if procMapRange.Symbols != nil {
+		return procMapRange.Symbols
 	}
 
+	symbols, ok := u.symbolCache[procMapRange.BinaryPath]
+	if ok {
+		procMapRange.Symbols = symbols
+		return symbols
+	}
+
+	symbols, _ = LoadSymbols(procMapRange.BinaryPath)
+	u.symbolCache[procMapRange.BinaryPath] = symbols
+	procMapRange.Symbols = symbols
+	return symbols
+}
+
+func UserSymbolNotFoundNode(address SymbolAddr) StackTraceNode {
 	return StackTraceNode{
 		Type:   User,
 		Symbol: SymbolNotFound,
 		FuncID: -1,
 		Offset: address,
+	}
+}
+
+// ResolveUserSymbolAndOffset returns the symbol of the function in which a given address lives, as well as the offset
+// inside that function
+func (u *UTrace) ResolveUserSymbolAndOffset(address SymbolAddr, pid int) StackTraceNode {
+	var symbol *elf.Symbol = nil
+	procMapRange := u.GetProcMapRange(address, pid)
+	if procMapRange == nil {
+		return UserSymbolNotFoundNode(address)
+	}
+	offset := uint64(address) - procMapRange.Start + procMapRange.Offset
+	symbols := u.GetSymbols(procMapRange)
+	if symbols == nil {
+		return UserSymbolNotFoundNode(address)
+	}
+	symbol = symbols.Search(offset)
+	if symbol == nil {
+		return UserSymbolNotFoundNode(address)		
+	}
+	
+	var funcID FuncID = 1
+	// funcID, ok := binary.symbolNameToFuncID[symbol.Name]
+	// if !ok {
+	// funcID = -1
+	// }
+	return StackTraceNode{
+		Type:   User,
+		Symbol: *symbol,
+		FuncID: funcID,
+		Offset: address - SymbolAddr(symbol.Value),
 	}
 }
 
@@ -959,7 +1088,7 @@ func (u *UTrace) TraceEventsHandler(Cpu int, data []byte, perfMap *manager.PerfM
 		if addr == 0 {
 			break
 		}
-		stackTrace.UserStacktrace = append(stackTrace.UserStacktrace, u.ResolveUserSymbolAndOffset(addr, binary))
+		stackTrace.UserStacktrace = append(stackTrace.UserStacktrace, u.ResolveUserSymbolAndOffset(addr, int(evt.Pid)))
 	}
 
 	// resolve kernel stack trace

--- a/pkg/utrace/utrace.go
+++ b/pkg/utrace/utrace.go
@@ -315,7 +315,7 @@ func (u *UTrace) insertTracedBinary(path string, pid int) error {
 
 func (u *UTrace) generateTracedBinaries() error {
 	var err error
-	for _, binary := range u.options.Binary {
+	for _, binary := range u.options.Executables {
 		if err = u.insertTracedBinary(binary, 0); err != nil {
 			return err
 		}
@@ -454,7 +454,7 @@ func (u *UTrace) generateUProbes(binary *TracedBinary) error {
 	// from the entire list of symbols, only keep the functions that match the provided pattern
 	var matches []elf.Symbol
 	for _, sym := range binary.symbolsCache {
-		if elf.ST_TYPE(sym.Info) == elf.STT_FUNC && u.options.FuncPattern.MatchString(sym.Name) {
+		if elf.ST_TYPE(sym.Info) == elf.STT_FUNC && u.options.FuncPattern.Pattern.MatchString(sym.Name) {
 			matches = append(matches, sym)
 		}
 	}
@@ -465,7 +465,7 @@ func (u *UTrace) generateUProbes(binary *TracedBinary) error {
 	}
 
 	if len(matches) == 0 {
-		return fmt.Errorf("no symbol in '%s' match the provided pattern '%s'", binary.Path, u.options.FuncPattern.String())
+		return fmt.Errorf("no symbol in '%s' match the provided pattern '%s'", binary.Path, u.options.FuncPattern.Pattern.String())
 	}
 
 	// relocate the function address with the base address of the binary
@@ -643,7 +643,7 @@ func (u *UTrace) generateKProbes() error {
 				probe.ProbeIdentificationPair,
 			},
 		})
-		if len(u.options.Binary) > 0 || len(u.options.PIDFilter) > 0 {
+		if len(u.options.Executables) > 0 || len(u.options.PIDFilter) > 0 {
 			constantEditors = append(constantEditors, manager.ConstantEditor{
 				Name:  "filter_user_binary",
 				Value: uint64(1),
@@ -674,7 +674,7 @@ func (u *UTrace) generateKProbes() error {
 					retProbe.ProbeIdentificationPair,
 				},
 			})
-			if len(u.options.Binary) > 0 || len(u.options.PIDFilter) > 0 {
+			if len(u.options.Executables) > 0 || len(u.options.PIDFilter) > 0 {
 				constantEditors = append(constantEditors, manager.ConstantEditor{
 					Name:  "filter_user_binary",
 					Value: uint64(1),
@@ -739,7 +739,7 @@ func (u *UTrace) generateTracepoints() error {
 				probe.ProbeIdentificationPair,
 			},
 		})
-		if len(u.options.Binary) > 0 || len(u.options.PIDFilter) > 0 {
+		if len(u.options.Executables) > 0 || len(u.options.PIDFilter) > 0 {
 			constantEditors = append(constantEditors, manager.ConstantEditor{
 				Name:  "filter_user_binary",
 				Value: uint64(1),
@@ -826,7 +826,7 @@ func (u *UTrace) generatePerfEvents(binary *TracedBinary) error {
 					probe.ProbeIdentificationPair,
 				},
 			})
-			if len(u.options.Binary) > 0 || len(u.options.PIDFilter) > 0 {
+			if len(u.options.Executables) > 0 || len(u.options.PIDFilter) > 0 {
 				if pid > 0 {
 					probe.PerfEventPID = pid
 				}


### PR DESCRIPTION
- When pid option is specified, check all binaries from proc maps.
- Lazy symbolization
Retrieve symbols when needed. Add a cache to check if symbols were loaded.

Authored by @nsavoire